### PR TITLE
Fix <Popup /> Incorrect position

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -67,9 +67,7 @@ export const position = (placement, node, target, offsetParent, arrowSize = 0) =
 
   const popupRect = {
     top: offset.top + offsetBcr.top,
-    left: offset.left + offsetBcr.left,
-    bottom: offset.top + offsetBcr.top,
-    right: offset.left + offsetBcr.left,
+    left: offset.left + offsetBcr.left
   }
 
   return {
@@ -80,7 +78,7 @@ export const position = (placement, node, target, offsetParent, arrowSize = 0) =
 
 export const isInViewport = (rect) => (
   rect.top >= 0 &&
+  rect.top <= (window.innerHeight || document.documentElement.clientHeight) &&
   rect.left >= 0 &&
-  rect.bottom <= (window.innerWidth || document.documentElement.clientWidth) &&
-  rect.right <= (window.innerHeight || document.documentElement.clientHeight)
+  rect.left <= (window.innerWidth || document.documentElement.clientWidth)
 )


### PR DESCRIPTION
Hi huozhi,

When reading the doc page, I noticed that it didn't give us the right popup position for the tooltip, as show in the picture below:

![image](https://user-images.githubusercontent.com/13282699/34439639-4407c812-ecea-11e7-9435-950ec96d4db4.png)

After doing some research, I found that the bug lies in the `isInViewport` function. In the conditional expressions, **`bottom` should be compared to window's `height`, not `width`**, and same with `right`.

On second thought tho, in the return result, `popupRect`, the properties are duplicated in `top === bottom` and `left === right`. So I removed them to enhance readability. And it fixes the issue in the picture.

Feel free to leave comments below. Great project! 😄 